### PR TITLE
Offset value fix for the last Crop layer in the FCN8s

### DIFF
--- a/voc-fcn8s/deploy.prototxt
+++ b/voc-fcn8s/deploy.prototxt
@@ -606,6 +606,6 @@ layer {
   top: "score"
   crop_param {
     axis: 2
-    offset: 31
+    offset: 34
   }
 }


### PR DESCRIPTION
Hi, I'm using the FCN8s as a great example for the Intel CV SDK (https://software.intel.com/en-us/computer-vision-sdk-support/code-samples).
The network is greatly accelerated with OpenV. The Crop and Deconv that are not supported by the SDK out of the box, are implemented as OpenCL kernels that extend the OpenVX.
However, seemingly the current offset value for the last Crop in the FC8s's prototxt is incorrect.
Specifically, the previous layer (deconv) produces an output of the 568x568. The final output of the entire network is 500x500.
So the Crop, which is last layer in the topology, should shave off the 68x68, i.e. offset should be 34 (as Crop is central), not 31.
If I got it wrong, could you please point to some reference behind current Crop's dimensions math.